### PR TITLE
Adding support for nested menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,22 @@ following in your project.clj
 
 Usage is pretty straight forward.  Menus are described using composable functions.
 
-        (popup-menu
-		(menu-item :title fn)
-		(menu-item :another-title another-fn)
-		(separator)
-		(menu-item :Exit exit-fn))
+    (popup-menu
+        (menu-item :title fcn)
+        (menu-item "another title" another-fn)
+        (separator)
+        (menu "more options"
+            (menu-item "deep item 1" fcn)
+            (menu-item "deep item 2" fcn)
+            (separator)
+            (menu-item :deep-item-3 fcn))
+        (menu-item :exit-title exit-fn))
 
 This can then be used with the tray icon like so:
 
      (make-tray-icon! path-to-icon popup-menu)
+
+![image](https://cloud.githubusercontent.com/assets/56411/6353164/9df71070-bc15-11e4-9114-e22e1e1e450d.png)
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-systemtray "0.1.4"
+(defproject clj-systemtray "0.2.1"
   :description "Clojure interface to the awt systemtray interface."
   :url "https://github.com/mbsmith/clj-systemtray"
   :license {:name "Eclipse Public License"

--- a/src/clj_systemtray/core.clj
+++ b/src/clj_systemtray/core.clj
@@ -54,7 +54,7 @@
        (separator)
        (menu \"more options\"
          (menu-item \"deep item 1\" fn)
-         (menu-item \"deep item 2\" fn)
+         (menu-item \"deep item 2\" fn))
        (menu-item :exit-title exit-fn))"
   [& args]
   (cons :popup args))

--- a/src/clj_systemtray/core.clj
+++ b/src/clj_systemtray/core.clj
@@ -39,9 +39,9 @@
   [v]
   (if (and (coll? v) (not (map? v)))
     (and (keyword?  (first v))
-         (= (name (first v)) "popup"))
+         (= (first v) :popup))
     (and (keyword? v)
-         (= (name v) "popup"))))
+         (= v :popup))))
 
 (defn popup-menu
   "Every menu definition should be enclosed within a popup-menu expression.
@@ -76,8 +76,7 @@
 
 (defn menu-item
   "Most of the menu is going to be composed of menu-items.  Each one has a title
-   and a corresponding function.  The function is *not* mandatory however.  The
-   title should be a keyword;  E.g. :title."
+   and a mandatory corresponding function. The title must be a string or keyword."
   [title fn]
   {title fn})
 

--- a/test/clj_systemtray/core_test.clj
+++ b/test/clj_systemtray/core_test.clj
@@ -17,6 +17,13 @@
     (is (keyword? sep) "The output should be a keyword.")
     (is (= sep :separator) "The keyword should be :separator.")))
 
+(deftest test-submenu
+  (let [m (menu "full" "one" :two 3)
+        mt (menu "empty")]
+    (is (menu? m) "menu? should recognize a menu.")
+    (is (menu? mt) "menu? should recognize an empty menu.")
+    (is (= (menu "asdf" :contents) [:menu "asdf" :contents]) "A menu should contain :menu, it's title, and any other passed arguments")))
+
 (deftest test-popup-menu
   (is (instance? clojure.lang.PersistentList (popup-menu))
       "Empty popup-menu should be a persistent list.")


### PR DESCRIPTION
Hey Michael, I've added support for nested menus, added tests, and updated the documentation.

Here's the syntax

```
(popup-menu
    (menu-item :title fcn)
    (menu-item "another title" another-fn)
    (separator)
    (menu "more options"                 <-- Here's the new thing, which can
        (menu-item "deep item 1" fcn)        be nested however deeply
        (menu-item "deep item 2" fcn)
        (separator)
        (menu-item :deep-item-3 fcn))
    (menu-item :exit-title exit-fn))

```

which produces this menu:

![image](https://cloud.githubusercontent.com/assets/56411/6353164/9df71070-bc15-11e4-9114-e22e1e1e450d.png)

I messed with how `process-menu` works pretty extensively. I hope you don't mind. I think it's simpler now.
I also did some minor cleanup, and added support for string titles in addition to keywords because I need that.
