### PR TITLE
Fix reflection warning

### DIFF
--- a/src/clj_systemtray/core.clj
+++ b/src/clj_systemtray/core.clj
@@ -179,7 +179,7 @@
   (tray-or-throw!)
   (let [tray (SystemTray/getSystemTray)
         tray-icon (TrayIcon. (.getImage (Toolkit/getDefaultToolkit)
-                                        icon-path))]
+                                        ^String icon-path))]
     (when menu
       (.setPopupMenu tray-icon (process-menu menu)))
     (.setImageAutoSize tray-icon true)
@@ -209,16 +209,3 @@
                    :warning java.awt.TrayIcon$MessageType/WARNING
                    :error java.awt.TrayIcon$MessageType/ERROR)]
     (.displayMessage tray-icon caption message msg-type)))
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/clj_systemtray/core.clj
+++ b/src/clj_systemtray/core.clj
@@ -160,6 +160,20 @@
 
 ;; ## Dealing with the tray
 
+;; avoid reflection (Toolkit/getImage accepts a String or a URL)
+(defmulti get-image!
+  (fn [icon-path] (class icon-path)))
+
+(defmethod get-image! java.net.URL
+  [^java.net.URL icon-path]
+  (.getImage (Toolkit/getDefaultToolkit)
+             icon-path))
+
+(defmethod get-image! String
+  [^String icon-path]
+  (.getImage (Toolkit/getDefaultToolkit)
+             icon-path))
+
 (defn make-tray-icon!
   "Now with the previous functions defined we can finally create the tray icon.
    This function takes two arguments.  The first one being the path to the icon
@@ -178,8 +192,7 @@
   [icon-path menu]
   (tray-or-throw!)
   (let [tray (SystemTray/getSystemTray)
-        tray-icon (TrayIcon. (.getImage (Toolkit/getDefaultToolkit)
-                                        ^String icon-path))]
+        tray-icon (TrayIcon. (get-image! icon-path))]
     (when menu
       (.setPopupMenu tray-icon (process-menu menu)))
     (.setImageAutoSize tray-icon true)


### PR DESCRIPTION
Hi,

users running `clj-systemtray` on Java 9 and above get a [reflection warning](https://clojure.org/guides/faq#illegal_access) that is fixed by this PR.

I was too ashamed to commit a single-word diff, so I have removed some white space at the end of the file, too... :smile:

Thanks for your system tray wrapper,

Martin